### PR TITLE
Toggling line wrap and readonly

### DIFF
--- a/haxe/ui/backend/ComponentBase.hx
+++ b/haxe/ui/backend/ComponentBase.hx
@@ -232,7 +232,58 @@ class ComponentBase {
             window.bind(EventType.ERASE_BACKGROUND, function(e) {
 
             });
-        }        
+        }
+    }
+
+    private function replaceWindow(replacement:Window) {
+        if (replacement == null) {
+            return;
+        }
+        __children = [];
+
+        cast(this, Component).invalidateStyle(false);
+        window.destroy();
+        window = replacement;
+
+        var platform:PlatformInfo = new PlatformInfo();
+        if (Std.is(window, Notebook)) {
+            if (platform.isWindows) {
+                var n:Notebook = cast window;
+                n.padding = new hx.widgets.Size(6, 6);
+                //n.backgroundColour = 0xF0F0F0;
+                //n.refresh();
+            }
+        }
+
+        if (Std.is(window, ScrollBar)) {
+            var scrollbar:ScrollBar = cast window;
+            scrollbar.setScrollbar(0, 5, 100, 5);
+        }
+
+        if (Std.is(__parent, haxe.ui.containers.TabView)) {
+            var n:Notebook = cast __parent.window;
+            var pageTitle:String = cast(this, Component).text;
+            var pageIcon:String = cast(this, Box).icon;
+            var iconIndex:Int = TabViewIcons.getImageIndex(cast __parent, pageIcon);
+            n.addPage(window, pageTitle, iconIndex);
+        }
+
+        if (Std.parseInt(cast(this, Component).id) != null) {
+            window.id = Std.parseInt(cast(this, Component).id);
+        }
+
+        if (__eventsToMap != null) {
+            for (type in __eventsToMap.keys()) {
+                mapEvent(type, __eventsToMap.get(type));
+            }
+            __eventsToMap = null;
+        }
+
+        if (Std.is(window, Button) || Std.is(window, StaticText)) {
+            window.bind(EventType.ERASE_BACKGROUND, function(e) {
+
+            });
+        }
     }
 
     private var _paintStyle:Style = null;

--- a/haxe/ui/backend/ComponentBase.hx
+++ b/haxe/ui/backend/ComponentBase.hx
@@ -204,35 +204,7 @@ class ComponentBase {
             }
         }
 
-        if (Std.is(window, ScrollBar)) {
-            var scrollbar:ScrollBar = cast window;
-            scrollbar.setScrollbar(0, 5, 100, 5);
-        }
-
-        if (Std.is(__parent, haxe.ui.containers.TabView)) {
-            var n:Notebook = cast __parent.window;
-            var pageTitle:String = cast(this, Component).text;
-            var pageIcon:String = cast(this, Box).icon;
-            var iconIndex:Int = TabViewIcons.getImageIndex(cast __parent, pageIcon);
-            n.addPage(window, pageTitle, iconIndex);
-        }
-
-        if (Std.parseInt(cast(this, Component).id) != null) {
-            window.id = Std.parseInt(cast(this, Component).id);
-        }
-
-        if (__eventsToMap != null) {
-            for (type in __eventsToMap.keys()) {
-                mapEvent(type, __eventsToMap.get(type));
-            }
-            __eventsToMap = null;
-        }
-
-        if (Std.is(window, Button) || Std.is(window, StaticText)) {
-            window.bind(EventType.ERASE_BACKGROUND, function(e) {
-
-            });
-        }
+        setupWindow();
     }
 
     private function replaceWindow(replacement:Window) {
@@ -245,6 +217,10 @@ class ComponentBase {
         window.destroy();
         window = replacement;
 
+        setupWindow();
+    }
+
+    private function setupWindow() {
         var platform:PlatformInfo = new PlatformInfo();
         if (Std.is(window, Notebook)) {
             if (platform.isWindows) {

--- a/haxe/ui/backend/TextInputBase.hx
+++ b/haxe/ui/backend/TextInputBase.hx
@@ -10,4 +10,5 @@ class TextInputBase extends TextDisplayBase {
     public var multiline:Bool;
     public var password:Bool;
     public var wordWrap:Bool;
+    public var readOnly:Bool;
 }

--- a/haxe/ui/backend/hxwidgets/StyleParser.hx
+++ b/haxe/ui/backend/hxwidgets/StyleParser.hx
@@ -31,6 +31,7 @@ class StyleParser {
             case "ScrollBarStyle.VERTICAL":             return ScrollBarStyle.VERTICAL;
             case "TextCtrlStyle.MULTILINE":             return TextCtrlStyle.MULTILINE;
             case "TextCtrlStyle.HSCROLL":               return TextCtrlStyle.HSCROLL;
+            case "TextCtrlStyle.READONLY":               return TextCtrlStyle.READONLY;
             default:
                 trace('WARNING: hxWidgets style "${style}" not recognised');
         }

--- a/haxe/ui/backend/hxwidgets/behaviours/ControlReadOnly.hx
+++ b/haxe/ui/backend/hxwidgets/behaviours/ControlReadOnly.hx
@@ -1,0 +1,63 @@
+package haxe.ui.backend.hxwidgets.behaviours;
+
+import haxe.ui.util.Variant;
+import haxe.ui.components.TextArea;
+import hx.widgets.Bitmap;
+import hx.widgets.Control;
+import hx.widgets.Button;
+import hx.widgets.StaticText;
+import hx.widgets.TextCtrl;
+import hx.widgets.styles.TextCtrlStyle;
+
+@:keep
+@:access(haxe.ui.core.Component)
+class ControlReadOnly extends HxWidgetsBehaviour {
+    public override function set(value:Variant) {
+        super.set(value);
+        if (_component.window == null) {
+            return;
+        }
+
+        var ctrl:Control = cast _component.window;
+        if (value.isNull == false) {
+            if (Std.is(_component.window, TextCtrl)) {
+                var textctrl:TextCtrl = cast _component.window;
+                var style = textctrl.windowStyle;
+
+                if (value == false && (style & TextCtrlStyle.READONLY > 0)) {
+                    style -= TextCtrlStyle.READONLY;
+                }
+                if (value == true) {
+                    style |= TextCtrlStyle.READONLY;
+                }
+
+                var text = textctrl.value;
+                var parent =  textctrl.parent;
+                var id =  textctrl.id;
+
+                var replacement = new TextCtrl(parent, text, style, id);
+                replacement.size = textctrl.size;
+                replacement.position = textctrl.position;
+                _component.replaceWindow(replacement);
+            }
+            _component.invalidateLayout();
+        }
+
+
+        var textArea:TextArea = cast _component;
+        textArea.getTextInput().readOnly = value;
+    }
+
+    public override function get():Variant {
+        if (_component.window == null) {
+            return null;
+        }
+
+        if (Std.is(_component.window, TextCtrl)) {
+            var textctrl:TextCtrl = cast _component.window;
+            return !(textctrl.windowStyle & TextCtrlStyle.DONTWRAP > 0);
+        }
+
+        return null;
+    }
+}

--- a/haxe/ui/backend/hxwidgets/behaviours/ControlReadOnly.hx
+++ b/haxe/ui/backend/hxwidgets/behaviours/ControlReadOnly.hx
@@ -55,7 +55,7 @@ class ControlReadOnly extends HxWidgetsBehaviour {
 
         if (Std.is(_component.window, TextCtrl)) {
             var textctrl:TextCtrl = cast _component.window;
-            return !(textctrl.windowStyle & TextCtrlStyle.DONTWRAP > 0);
+            return (textctrl.windowStyle & TextCtrlStyle.READONLY) > 0;
         }
 
         return null;

--- a/haxe/ui/backend/hxwidgets/behaviours/ControlWrap.hx
+++ b/haxe/ui/backend/hxwidgets/behaviours/ControlWrap.hx
@@ -1,0 +1,63 @@
+package haxe.ui.backend.hxwidgets.behaviours;
+
+import haxe.ui.util.Variant;
+import haxe.ui.components.TextArea;
+import hx.widgets.Bitmap;
+import hx.widgets.Control;
+import hx.widgets.Button;
+import hx.widgets.StaticText;
+import hx.widgets.TextCtrl;
+import hx.widgets.styles.TextCtrlStyle;
+
+@:keep
+@:access(haxe.ui.core.Component)
+class ControlWrap extends HxWidgetsBehaviour {
+    public override function set(value:Variant) {
+        super.set(value);
+        if (_component.window == null) {
+            return;
+        }
+
+        var ctrl:Control = cast _component.window;
+        if (value.isNull == false) {
+            if (Std.is(_component.window, TextCtrl)) {
+                var textctrl:TextCtrl = cast _component.window;
+                var style = textctrl.windowStyle;
+                if (value == true && (style & TextCtrlStyle.DONTWRAP > 0)) {
+                    style -= TextCtrlStyle.DONTWRAP;
+                }
+                else if (value == false && (style & TextCtrlStyle.BESTWRAP > 0)) {
+                    style -= TextCtrlStyle.BESTWRAP;
+                }
+                style |= (value == true) ? TextCtrlStyle.BESTWRAP : TextCtrlStyle.DONTWRAP;
+                var text = textctrl.value;
+                var parent =  textctrl.parent;
+                var id =  textctrl.id;
+
+                var replacement = new TextCtrl(parent, text, style, id);
+                replacement.size = textctrl.size;
+                replacement.position = textctrl.position;
+                _component.replaceWindow(replacement);
+            }
+            _component.invalidateLayout();
+        }
+
+
+        var textArea:TextArea = cast _component;
+        textArea.getTextInput().wordWrap = value;
+        textArea.checkScrolls();
+    }
+
+    public override function get():Variant {
+        if (_component.window == null) {
+            return null;
+        }
+
+        if (Std.is(_component.window, TextCtrl)) {
+            var textctrl:TextCtrl = cast _component.window;
+            return !(textctrl.windowStyle & TextCtrlStyle.DONTWRAP > 0);
+        }
+
+        return null;
+    }
+}

--- a/haxe/ui/backend/hxwidgets/behaviours/ControlWrap.hx
+++ b/haxe/ui/backend/hxwidgets/behaviours/ControlWrap.hx
@@ -55,7 +55,7 @@ class ControlWrap extends HxWidgetsBehaviour {
 
         if (Std.is(_component.window, TextCtrl)) {
             var textctrl:TextCtrl = cast _component.window;
-            return !(textctrl.windowStyle & TextCtrlStyle.DONTWRAP > 0);
+            return !((textctrl.windowStyle & TextCtrlStyle.DONTWRAP) > 0);
         }
 
         return null;

--- a/haxe/ui/backend/native.xml
+++ b/haxe/ui/backend/native.xml
@@ -33,6 +33,8 @@
     <component id="haxe.ui.components.TextArea" class="hx.widgets.TextCtrl" constructor="null, $style" allowChildren="false" style="TextCtrlStyle.MULTILINE, TextCtrlStyle.HSCROLL">
         <behaviour id="text" class="haxe.ui.backend.hxwidgets.behaviours.ControlLabel" />
         <behaviour id="disabled" class="haxe.ui.backend.hxwidgets.behaviours.ControlDisable" />
+        <behaviour id="wrap" class="haxe.ui.backend.hxwidgets.behaviours.ControlWrap" />
+        <behaviour id="readOnly" class="haxe.ui.backend.hxwidgets.behaviours.ControlReadOnly" />
         <size class="haxe.ui.backend.hxwidgets.size.BestSize" includePadding="false" />
     </component>
     <component id="haxe.ui.components.HProgress" class="hx.widgets.Gauge" constructor="100, $style" allowChildren="false">


### PR DESCRIPTION
Make possible to toggle the style for wrapping and editing by replacing the widget by a new one with required styles (#11).

Might require https://github.com/haxeui/haxeui-core/pull/133