### PR TITLE
ScrollView.addComponentAt(): use setComponentIndex if already a child component

### DIFF
--- a/haxe/ui/backend/hxwidgets/builders/ScrollViewBuilder.hx
+++ b/haxe/ui/backend/hxwidgets/builders/ScrollViewBuilder.hx
@@ -21,6 +21,10 @@ class ScrollViewBuilder extends CompositeBuilder {
     
     public override function addComponentAt(child:Component, index:Int):Component {
         if (child.hasClass("scrollview-contents") == false) {
+            if (Lambda.has(_contents.childComponents, child)) {
+                return setComponentIndex(child, index);
+            }
+
             return _contents.addComponentAt(child, index);
         }
         return null;


### PR DESCRIPTION
Probably not the best fix, but coconut.haxeui fails to identify child
component as being a child of ScrollView because of the intermediate
container, and calls addComponentAt() instead of setComponentIndex(),
leading to strange bugs