### PR TITLE
to be able to set selectedItem

### DIFF
--- a/haxe/ui/backend/hxwidgets/behaviours/DataComponentSelectedItem.hx
+++ b/haxe/ui/backend/hxwidgets/behaviours/DataComponentSelectedItem.hx
@@ -28,4 +28,19 @@ class DataComponentSelectedItem extends DataBehaviour {
         
         return selectedItem;
     }
+    
+    public override function setDynamic(value:Dynamic) {
+        _value = value;
+        var text = "";
+        if (Type.typeof(value) == TObject) {
+            text = value.text;
+            if (text == null) {
+                text = value.value;
+            }
+        } else {
+            text = Std.string(value);
+        }
+                
+        _component.text = text;
+    }
 }


### PR DESCRIPTION
Now , something like this will work even though it's not perfect

```

@:xml('
<vbox width="100%" height="100%">
        <dropdown id="dropdown" text="Select Item">
            <data>
                <item text="Item 1" />
                <item text="Item 2" />
                <item text="Item 3" />
                <item text="Item 4" />
            </data>
        </dropdown>
</vbox>')
class A007 extends VBox {


    public function new() {
        
        super();

        dropdown.selectedItem = {text:"Item 3"};
        trace(dropdown.selectedItem); // this doesn't work
        dropdown.registerEvent(UIEvent.READY, function f(e) {
            trace(dropdown.selectedItem); // this works
        }
            
            );
    }

}

```