### PR TITLE
Listview with multiple selections

### DIFF
--- a/haxe/ui/backend/hxwidgets/behaviours/DataComponentSelectedItems.hx
+++ b/haxe/ui/backend/hxwidgets/behaviours/DataComponentSelectedItems.hx
@@ -1,0 +1,78 @@
+package haxe.ui.backend.hxwidgets.behaviours;
+
+import haxe.ui.data.DataSource;
+import haxe.ui.behaviours.DataBehaviour;
+import haxe.ui.components.DropDown;
+import haxe.ui.containers.ListView;
+import haxe.ui.core.IDataComponent;
+import haxe.ui.util.Variant;
+
+class DataComponentSelectedItems extends DataBehaviour {
+
+    public override function get():Variant {
+        if ((_component is IDataComponent) == false) {
+            return false;
+        }
+
+        var dataComponent:IDataComponent = cast(_component, IDataComponent);
+        var ds = dataComponent.dataSource;
+        var selectedItems:Array<Dynamic> = [];
+
+        if ((_component is ListView)) {
+            var listview = cast(_component, ListView);
+            for (i in listview.selectedIndices) {
+                selectedItems.push(ds.get(i));
+            }
+        }
+        
+        return selectedItems;
+    }
+
+    public override function set(value:Variant):Void {
+        _value = value;
+        var dataComponent:IDataComponent = cast(_component, IDataComponent);
+        var selectedIndices = [];
+
+        var ds = dataComponent.dataSource;
+        var values:Array<Dynamic> = value;
+        for (item in values) {
+            var selectedIndex = findIndexOfItem(value, ds);
+            selectedIndices.push(selectedIndex);
+        }
+       
+        if ((_component is ListView)) {
+            var listview = cast(_component, ListView).selectedIndices = selectedIndices;
+        }
+    }
+
+    private function findIndexOfItem(value:Dynamic, ds:DataSource<Dynamic>) {
+        var n = -1;
+
+        var text = valueToString(value);
+        if (text == null) {
+            return -1;
+        }
+
+        for (i in 0...ds.size) {
+            if (text == valueToString(ds.get(i))) {
+                n = i;
+                break;
+            }
+        }
+
+        return n;
+    }
+
+    private function valueToString(value:Dynamic):String {
+        var text = null;
+        if (Type.typeof(value) == TObject) {
+            text = value.text;
+            if (text == null) {
+                text = value.value;
+            }
+        } else {
+            text = Std.string(value);
+        }
+        return text;
+    }
+}

--- a/haxe/ui/backend/hxwidgets/behaviours/ListViewSelectedIndices.hx
+++ b/haxe/ui/backend/hxwidgets/behaviours/ListViewSelectedIndices.hx
@@ -1,0 +1,35 @@
+package haxe.ui.backend.hxwidgets.behaviours;
+
+import haxe.ui.behaviours.DataBehaviour;
+import haxe.ui.util.Variant;
+import hx.widgets.ListView;
+
+class ListViewSelectedIndices extends DataBehaviour {
+    
+    private override function validateData() {
+        if (_component.window == null) {
+            return;
+        }
+
+        if (!_value.isArray) {
+            return;
+        }
+        
+        var view:ListView = cast(_component.window, ListView);
+        view.selectedIndexes = _value;
+
+        for (i in (_value:Array<Int>)) {
+            view.ensureVisible(i);
+        }
+    }
+    
+    public override function get():Variant {
+        if (_component.window == null) {
+            return -1;
+        }
+        
+        var view:ListView = cast(_component.window, ListView);
+        return view.selectedIndexes;
+        
+    }
+}

--- a/haxe/ui/backend/hxwidgets/creators/ListViewCreator.hx
+++ b/haxe/ui/backend/hxwidgets/creators/ListViewCreator.hx
@@ -1,0 +1,21 @@
+package haxe.ui.backend.hxwidgets.creators;
+import haxe.ui.containers.ListView;
+import haxe.ui.constants.SelectionMode;
+import hx.widgets.Defs;
+import hx.widgets.styles.ListCtrlStyle;
+
+class ListViewCreator extends Creator {
+    private var _listView:ListView;
+    
+    public function new(listView:ListView) {
+        super(listView);
+        _listView = listView;
+    }
+    
+    public override function createConstructorParams(params:Array<Dynamic>):Array<Dynamic> {
+        var style = 0;
+        if (_listView.selectionMode == SelectionMode.ONE_ITEM) style |= ListCtrlStyle.SINGLE_SEL;
+        params.push(style);
+        return params;
+    }
+}

--- a/haxe/ui/backend/hxwidgets/custom/SimpleListView.hx
+++ b/haxe/ui/backend/hxwidgets/custom/SimpleListView.hx
@@ -8,7 +8,7 @@ import hx.widgets.styles.ListCtrlStyle;
 
 class SimpleListView extends ListView {
     public function new(parent:Window, style:Int = 0, id:Int = -1) {
-        super(parent, ListCtrlStyle.REPORT | ListCtrlStyle.NO_HEADER | ListCtrlStyle.SINGLE_SEL | style, id);
+        super(parent, ListCtrlStyle.REPORT | ListCtrlStyle.NO_HEADER | style, id);
         appendColumn("");
         bind(EventType.SIZE, onResized);
     }

--- a/haxe/ui/backend/native.xml
+++ b/haxe/ui/backend/native.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <native>
-    <component id="haxe.ui.containers.ListView" class="haxe.ui.backend.hxwidgets.custom.SimpleListView" allowChildren="false">
+    <component id="haxe.ui.containers.ListView" class="haxe.ui.backend.hxwidgets.custom.SimpleListView" creator="haxe.ui.backend.hxwidgets.creators.ListViewCreator" allowChildren="false">
         <behaviour id="dataSource" class="haxe.ui.backend.hxwidgets.behaviours.ListViewDataSource" />
         <behaviour id="selectedIndex" class="haxe.ui.backend.hxwidgets.behaviours.ListViewSelectedIndex" />
+        <behaviour id="selectedIndices" class="haxe.ui.backend.hxwidgets.behaviours.ListViewSelectedIndices" />
         <behaviour id="contentLayoutName" class="haxe.ui.behaviours.DefaultBehaviour" />
         <behaviour id="selectedItem" class="haxe.ui.backend.hxwidgets.behaviours.DataComponentSelectedItem" />
+        <behaviour id="selectedItems" class="haxe.ui.backend.hxwidgets.behaviours.DataComponentSelectedItems" />
         <behaviour id="tooltip" class="haxe.ui.backend.hxwidgets.behaviours.ToolTipBehaviour" />
         <size class="haxe.ui.backend.hxwidgets.size.WindowSize" includePadding="false" />
         <event id="change" native="EventType.LIST_ITEM_SELECTED" />


### PR DESCRIPTION
![image](https://github.com/haxeui/haxeui-hxwidgets/assets/12767394/959c0f2f-d448-4aaa-9ae7-fbcb20cd0b53)


Can set indices, get items etc

Just two question. What is the point of one-item-repeated ? Maybe I should also force one line section for this selection mode.

Plus code question, I did this in ListViewSelectedIndices. 
`
for (i in (_value:Array<Int>)) {
            view.ensureVisible(i);
        }`
If someone do selectedIndices = ["aa", bb"]. Feels it could it break.  Wonder if there is a better way.

Needs https://github.com/haxeui/hxWidgets/pull/104
        